### PR TITLE
Fix custom map rendering

### DIFF
--- a/Bunject/Levels/CoreBunburrow.cs
+++ b/Bunject/Levels/CoreBunburrow.cs
@@ -52,5 +52,10 @@ namespace Bunject.Levels
     {
       return AssetsManager.SurfaceRightLevel;
     }
+
+    public Vector2Int? GetMapIndex()
+    {
+      return null;
+    }
   }
 }

--- a/Bunject/Levels/IModBunburrow.cs
+++ b/Bunject/Levels/IModBunburrow.cs
@@ -26,5 +26,7 @@ namespace Bunject.Levels
     LevelsList GetLevels();
 
     LevelObject GetSurfaceLevel();
+
+    Vector2Int? GetMapIndex();
   }
 }

--- a/Bunject/Patches/BunburrowExtensionPatches.cs
+++ b/Bunject/Patches/BunburrowExtensionPatches.cs
@@ -4,10 +4,7 @@ using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine.Assertions.Must;
+using UnityEngine;
 
 namespace Bunject.Patches.BunburrowExtensionPatches
 {
@@ -104,6 +101,53 @@ namespace Bunject.Patches.BunburrowExtensionPatches
         return BunburrowManager.Bunburrows.FirstOrDefault(bb => bb.ID == (int)bunburrow)?.ModBunburrow?.IsVoid ?? __result;
       }
       return __result;
+    }
+  }
+
+  [HarmonyPatch(typeof(BunburrowExtension), nameof(BunburrowExtension.GetBunburrowsInMapOrderList))]
+  internal class GetBunburrowsInMapOrderListPatch
+  {
+    // ALlow the map to see custom burrows
+    private static IEnumerable<Bunburrow> Postfix(IEnumerable<Bunburrow> values)
+    {
+      return CustomBunburrowExtension.GetRegularAndCustomBunbrrowEnumerator();
+    }
+  }
+
+  [HarmonyPatch(typeof(BunburrowExtension), nameof(BunburrowExtension.GetMapIndex))]
+  internal class GetMapIndexPatch
+  {
+    // Burrow to MapIndex lookup. 
+    private static bool Prefix(ref Vector2Int __result, Bunburrow bunburrow)
+    {
+      if ((int)bunburrow < BunburrowManager.CustomBunburrowThreshold)
+        return true;
+      var mod = bunburrow.GetModBunburrow();
+      __result = mod.GetMapIndex() ?? new Vector2Int(10, 10);
+      
+      return false;
+
+    }
+  }
+
+  [HarmonyPatch(typeof(BunburrowExtension), nameof(BunburrowExtension.TryGetBunburrowFromMapIndex))]
+  internal class TryGetBunburrowFromMapIndexPatch
+  {
+    // MapIndex to Burrow lookup, This could probably be cached somewhere.
+    private static bool Prefix(ref bool __result, Vector2Int mapIndex, out Bunburrow bunburrow)
+    {
+      var result = CustomBunburrowExtension.GetRegularAndCustomBunbrrowEnumerator()
+        .Where(x => x.IsCustomBunburrow())
+        .Select(x => x.GetModBunburrow())
+        .FirstOrDefault(x => x.GetMapIndex() == mapIndex);
+      if (result == null)
+      {
+        bunburrow = Bunburrow.Pink;
+        return true;
+      }
+      bunburrow = (Bunburrow)result.ID;
+      __result = true;
+      return false;
     }
   }
 }

--- a/BunjectNewYardSystem/Assets/BNYS/Pursuit/config.json
+++ b/BunjectNewYardSystem/Assets/BNYS/Pursuit/config.json
@@ -21,7 +21,8 @@
         "Right": "Burrow B",
         "Down": "Burrow A"
       },
-      "ElevatorDepths": [ 5 ]
+      "ElevatorDepths": [ 5 ],
+      "MapIndex": [ 0, 1 ]
     },
     {
       "Directory": "BurrowB",
@@ -39,7 +40,8 @@
         "Right": "Burrow A",
         "Down": "Burrow B"
       },
-      "ElevatorDepths": [ 9 ]
+      "ElevatorDepths": [ 9 ],
+      "MapIndex": [ 1, 1 ]
     }
   ],
   "SurfaceEntries": [

--- a/BunjectNewYardSystem/BNYSPlugin.cs
+++ b/BunjectNewYardSystem/BNYSPlugin.cs
@@ -153,6 +153,7 @@ namespace Bunject.NewYardSystem
         progression.HandleBunburrowSignsDiscovery();
         progression.HandleBackToSurfaceUnlock();
         progression.HandleOphelinePortableComputerUnlock();
+        progression.HandleTeleportAnywhereUnlock();
       }
     }
 

--- a/BunjectNewYardSystem/Levels/BNYSLostBunburrow.cs
+++ b/BunjectNewYardSystem/Levels/BNYSLostBunburrow.cs
@@ -54,5 +54,10 @@ namespace Bunject.NewYardSystem.Levels
     {
       return null;
     }
+
+    public Vector2Int? GetMapIndex()
+    {
+      return null;
+    }
   }
 }

--- a/BunjectNewYardSystem/Levels/BNYSModBunburrowBase.cs
+++ b/BunjectNewYardSystem/Levels/BNYSModBunburrowBase.cs
@@ -110,6 +110,11 @@ namespace Bunject.NewYardSystem.Levels
       return SurfaceLevel;
     }
 
+    public Vector2Int? GetMapIndex()
+    {
+      return new Vector2Int(BurrowModel.MapIndex[0], BurrowModel.MapIndex[1]);
+    }
+
     protected virtual BNYSLevelsList GenerateLevelsList()
     {
       var levelsList = ScriptableObject.CreateInstance<BNYSLevelsList>();

--- a/BunjectNewYardSystem/Levels/ContentValidator.cs
+++ b/BunjectNewYardSystem/Levels/ContentValidator.cs
@@ -25,7 +25,7 @@ namespace Bunject.NewYardSystem.Levels
      *   F - Fake bunny at start of game
      *   Y - SPOILERS
      */
-    private const string RESTRICTED_TILES = @"^(F|D[0-9]+|P[0-9]+|N[0-9]+|Oph|X|C|PU|A|Y(?:{.*})?)|T\{\.*[PS].*\}$";
+    private const string RESTRICTED_TILES = @"^(F|D[0-9]+|P[0-9]+|N[0-9]+|Oph|X|C|PU|A|Y(?:{.*})?)}$";
     private static readonly Regex restrictedTileRegex = new Regex(RESTRICTED_TILES);
 
     public static List<LevelValidationError> ValidateLevelContent(string content)

--- a/BunjectNewYardSystem/Model/Burrow.cs
+++ b/BunjectNewYardSystem/Model/Burrow.cs
@@ -26,6 +26,8 @@ namespace Bunject.NewYardSystem.Model
 
     public BurrowLinks Links { get; set; } = new BurrowLinks();
     public List<int> ElevatorDepths { get; set; } = new List<int>();
+    
+    public int[] MapIndex { get; set; }
 
     [JsonIgnore]
     public Uri ProxyUri { get; set; }


### PR DESCRIPTION
Allow the map to render custom burrows, assuming they have a MapIndex set. Example MapIndexes for normal levels are SW-[0,0] W-[0,1] and SE-[2,2].

Indexes <0 and >2 do work, but it is really hard to select them. It could be a future improvement to allow scrolling further for huge layouts.

I think this completely deprecates the Computer Map Plugin, but I didn't want to delete that without your input first.

Teleporting to levels *should* work as-is but LevelObject.TeleportPosition (the entry location) is not defined for custom levels yet.